### PR TITLE
Exclude twitter oembeds from wrapping with div

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -633,6 +633,14 @@ add_filter( 'embed_oembed_html', 'alx_embed_wmode_transparent', 10, 3 );
 if ( ! function_exists( 'alx_embed_html' ) ) {
 
 	function alx_embed_html( $html ) {
+	
+		$pattern    = '/^https?:\/\/(www\.)?twitter\.com/';
+		$is_twitter = preg_match( $pattern, $url );
+		
+		if ( 1 === $is_twitter ) {
+			return $html;
+		}
+	
 		return '<div class="video-container">' . $html . '</div>';
 	}
 


### PR DESCRIPTION
Twitter embeds works fine witout div.video-container.

If wrapped, twitter embed iframe doesn't show up.
