### PR TITLE
Fix: Allow child themes to load translation files

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,7 +25,7 @@ if ( ! function_exists( 'alx_load' ) ) {
 	
 	function alx_load() {
 		// Load theme languages
-		load_theme_textdomain( 'hueman', get_template_directory().'/languages' );
+		load_theme_textdomain( 'hueman', get_stylesheet_directory().'/languages' );
 		
 		// Load theme options and meta boxes
 		load_template( get_template_directory() . '/functions/theme-options.php' );


### PR DESCRIPTION
By changing the call of the path on `load_theme_textdomain` from `get_template_directory` to `get_stylesheet_directory` we allow the translation of the theme through child themes. Without this, a child theme won’t load their own language files even by hooking a function on `after_setup_theme` action callng `load_theme_textdomain` and/or `load_child_theme_textdomain`.
