### PR TITLE
The Return of the Video Embed Code

### DIFF
--- a/functions/init-admin.php
+++ b/functions/init-admin.php
@@ -418,7 +418,13 @@ function hu_custom_meta_boxes() {
           'id'    => '_video_url',
           'type'    => 'text',
           'desc'    => ''
-        )
+        ),
+		    array(
+			    'label'		=> 'Video Embed Code',
+			    'id'		=> '_video_embed_code',
+			    'type'		=> 'textarea',
+			    'rows'		=> '2'
+		    )
       )
     );
 

--- a/functions/widgets/alx-video.php
+++ b/functions/widgets/alx-video.php
@@ -31,6 +31,7 @@ class AlxVideo extends WP_Widget {
       'title'       => '',
     // Video
       'video_url'     => '',
+      'video_embed_code' 	=> '',
     );
   }
 
@@ -52,6 +53,11 @@ class AlxVideo extends WP_Widget {
 			global $wp_embed;
 			$video = $wp_embed->run_shortcode('[embed]'.$instance['video_url'].'[/embed]');
 		}
+		elseif ( !empty($instance['video_embed_code']) ) {
+			echo '<div class="video-container">';
+			$video = $instance['video_embed_code'];
+			echo '</div>';
+		}
 		else {
 			$video = '';
 		}
@@ -70,6 +76,7 @@ class AlxVideo extends WP_Widget {
 		$instance['title'] = esc_attr($new['title']);
 	// Video
 		$instance['video_url'] = esc_url($new['video_url']);
+		$instance['video_embed_code'] = $new['video_embed_code'];
 		return $instance;
 	}
 
@@ -99,6 +106,10 @@ class AlxVideo extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id("video_url") ); ?>">Video URL</label>
 			<input style="width:100%;" id="<?php echo esc_attr( $this->get_field_id("video_url") ); ?>" name="<?php echo esc_attr( $this->get_field_name("video_url") ); ?>" type="text" value="<?php echo esc_url( $instance["video_url"] ); ?>" />
+		</p>
+		<p>
+			<label for="<?php echo $this->get_field_id("video_embed_code"); ?>">Video Embed Code</label>
+			<textarea class="widefat" id="<?php echo $this->get_field_id('video_embed_code'); ?>" name="<?php echo $this->get_field_name('video_embed_code'); ?>"><?php echo $instance["video_embed_code"]; ?></textarea>
 		</p>
 	</div>
 <?php

--- a/parts/post-formats.php
+++ b/parts/post-formats.php
@@ -146,6 +146,11 @@
         $video = $wp_embed->run_shortcode('[embed]'.$meta['_video_url'][0].'[/embed]');
         echo $video;
       }
+      elseif ( isset($meta['_video_embed_code'][0]) && !empty($meta['_video_embed_code'][0]) ) {
+	    echo '<div class="video-container">';
+	    echo $meta['_video_embed_code'][0];
+	    echo '</div>';
+      }
     ?>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
The Video Embed Code custom field entry and display had been removed going from version 2.x to 3.x. This impacts those who relied upon the Video Embed Code field in the past and prevents them from upgrading to latest version which is not ideal.

Objective of this pull-request is to allow users of this post field to upgrade without issue.