### PR TITLE
improved "add to homescreen" (chrome/android)

### DIFF
--- a/header.php
+++ b/header.php
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="profile" href="http://gmpg.org/xfn/11">
   <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
+  <meta name="mobile-web-app-capable" content="yes">
 
   <?php wp_head(); ?>
 </head>


### PR DESCRIPTION
added support for meta-tag "mobile-web-app-capable" for improved "add to homescreen" (chrome/android)

see: https://developer.chrome.com/multidevice/android/installtohomescreen

effect: when you add the website to the homescreen (via chrome for android) it get's a nice splash screen (with the icon that wordpress provides)

![screenshot_20170217-224942](https://cloud.githubusercontent.com/assets/5737016/23084622/91d6f722-f563-11e6-9fdb-5c1890860856.png)
