### PR TITLE
make function hu_is_authorized_tmpl pluggable so it can be redefined to include custom templates

### DIFF
--- a/functions/init-front.php
+++ b/functions/init-front.php
@@ -44,15 +44,17 @@ if ( ! function_exists( 'hu_get_content') ) {
 
 //helper
 //@return bool
-function hu_is_authorized_tmpl( $tmpl ) {
-    $ct_map = apply_filters(
-        'hu_content_map',
-        array( 'tmpl/index-tmpl', 'tmpl/archive-tmpl', 'tmpl/page-tmpl', 'tmpl/single-tmpl', 'tmpl/search-tmpl', 'tmpl/404-tmpl' )
-    );
-    //Are we good after filtering ?
-    if ( ! is_array( $ct_map ) || ! is_string( $tmpl ) )
-      return;
-    return in_array( $tmpl, $ct_map );
+if( ! function_exists('hu_is_authorized_tmpl') ) {
+  function hu_is_authorized_tmpl( $tmpl ) {
+      $ct_map = apply_filters(
+          'hu_content_map',
+          array( 'tmpl/index-tmpl', 'tmpl/archive-tmpl', 'tmpl/page-tmpl', 'tmpl/single-tmpl', 'tmpl/search-tmpl', 'tmpl/404-tmpl' )
+      );
+      //Are we good after filtering ?
+      if ( ! is_array( $ct_map ) || ! is_string( $tmpl ) )
+        return;
+      return in_array( $tmpl, $ct_map );
+  }
 }
 
 


### PR DESCRIPTION
The function `hu_is_authorized_tmpl` controls which template files are acceptable. If web developers create custom post type and want to create a separate template file for it so that special features like custom taxonomies or custom fields may be shown, then the array defined in `hu_is_authorized_tmpl` function needs to be expanded. This can be done by redefining the function in functions.php. But to make that possible, it will need to be made [pluggable](http://docs.presscustomizr.com/article/239-using-a-child-theme-with-hueman) in its original place ie `functions/init-front.php`.

Referenced in #564

Additional requests regarding documentation: 
1. Please include instructions in the hueman documentation about redefining hu_is_authorized_tmpl in functions.php when creating custom templates.
2. Please update the [documentation](http://docs.presscustomizr.com/article/239-using-a-child-theme-with-hueman) to say that even if child theme has a separate `functions/init-front.php` file made, hueman will still load the parent theme's file only. Please fix this behaviour if that's not the way it's supposed to be.