### PR TITLE
Fix: make the color of the external link icon the same as the user

### DIFF
--- a/functions/dynamic-styles.php
+++ b/functions/dynamic-styles.php
@@ -269,6 +269,7 @@ function hu_get_primary_color_style() {
 
       $_primary_color_color_prop_selectors = array(
           'a',
+          'a+span.hu-external::after',
           '.themeform label .required',
           '#flexslider-featured .flex-direction-nav .flex-next:hover',
           '#flexslider-featured .flex-direction-nav .flex-prev:hover',


### PR DESCRIPTION
defined primary color
fixes #686