### PR TITLE
Imp: only clean free build when running hueman_dev grunt task

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
 				//DEV : clean the build and watch changes (see watch task)
 				'hueman_dev': [
             'replace:czr_fmk_namespace',
-            'clean',
+            'clean:free',
             'watch'
         ],
 


### PR DESCRIPTION
That's to avoid the annoying cleaning of the hueman-pro directory when running the hueman_dev task.