### PR TITLE
Fix: correctly display taxonomy/post_type_archive titles

### DIFF
--- a/parts/page-title.php
+++ b/parts/page-title.php
@@ -23,6 +23,10 @@
     		<h1><?php echo hu_get_term_page_title(); ?></h1>
     	<?php elseif ( is_day() || is_month() || is_year() ) : ?>
     		<h1><?php echo hu_get_date_archive_title(); ?></h1>
+    	<?php elseif ( is_tax() ) : ?>
+    		<h1><?php the_archive_title(); ?></h1>
+    	<?php elseif ( is_post_type_archive() ) : ?>
+    		<h1><?php post_type_archive_title(); ?></h1>
     	<?php else: ?>
         <?php if ( ! is_home() && ! hu_is_checked('blog-heading-enabled') ) : ?>
     		  <h2><?php the_title(); ?></h2>


### PR DESCRIPTION
fixes #750

tested with custom taxonxomies and custom post types:
https://codex.wordpress.org/Function_Reference/register_post_type#Example (elaborate)
https://codex.wordpress.org/Function_Reference/register_taxonomy#Basic_Example

Also tested with WooCommerce and The Events Calendar to make sure it didn't introduce
any issue.