### PR TITLE
Implement skip to content for TRT requirement

### DIFF
--- a/assets/front/css/_parts/0_1_base_styles.css
+++ b/assets/front/css/_parts/0_1_base_styles.css
@@ -328,3 +328,21 @@ h1, h2, h3, h4, h5, h6 { color: #444; font-weight: 600; -ms-word-wrap: break-wor
   overflow: visible;
   clip: auto;
 }
+
+.screen-reader-text.skip-link {
+  background-color: #f1f1f1;
+  box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+  color: #21759b;
+  font-weight: 700;
+  height: auto;
+  width: auto;
+  left: 5px;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  text-decoration: none;
+  top: 5px;
+}
+.screen-reader-text.skip-link:focus {
+    position: absolute;
+    z-index: 100000;
+}

--- a/functions/init-front.php
+++ b/functions/init-front.php
@@ -18,7 +18,7 @@ if ( ! function_exists( 'hu_get_content') ) {
     ob_start();
     ?>
       <?php do_action( '__before_content_section', $tmpl ); ?>
-        <section class="content">
+        <section class="content" id="content">
           <?php hu_get_template_part('parts/page-title'); ?>
           <div class="pad group">
             <?php

--- a/functions/init-plugins-compat.php
+++ b/functions/init-plugins-compat.php
@@ -395,7 +395,7 @@ function hu_is_plugin_active_for_network( $plugin ) {
 /*  Theme's wrappers (used by WooCommerce e.g.)
 /* ------------------------------------ */
 function hu_theme_wrapper_start() {
-  echo '<section class="content">';
+  echo '<section class="content" id="content">';
   if ( $page_title = apply_filters( 'hu_in_wrapper_page_title', '' ) )
     echo $page_title;
   echo '<div class="pad themeform">';

--- a/header.php
+++ b/header.php
@@ -19,7 +19,9 @@ if ( function_exists( 'wp_body_open' ) ) {
 }
 ?>
 <div id="wrapper">
-
+<?php if ( apply_filters( 'hu_skip_link', true ) ) : ?>
+  <a class="screen-reader-text skip-link" href="<?php echo apply_filters( 'hu_skip_link_anchor', '#content' ); ?>"><?php esc_html_e( 'Skip to content', 'hueman' ) ?></a>
+<?php endif ?>
   <?php do_action('__before_header') ; ?>
 
   <?php hu_get_template_part('parts/header-main'); ?>

--- a/page-templates/child-menu.php
+++ b/page-templates/child-menu.php
@@ -5,7 +5,7 @@ Template Name: Child Menu
 ?>
 <?php get_header(); ?>
 
-<section class="content">
+<section class="content" id="content">
 
 	<?php hu_get_template_part('parts/page-title'); ?>
 


### PR DESCRIPTION
fixes #824
also add the id 'content' to the main content theme section
and the following filters hooks:
'hu_skip_link' to control whether or not the skip link should be displayed (default true)
'hu_skip_link_anchor' the name of the content anchor (default '#content')